### PR TITLE
chore(docker): use digest instead of tag for chainguard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/git:2.41.0
+FROM cgr.dev/chainguard/git@sha256:549b8c78695131d41018e12e1c21107322227fd0669126f4bf13d00bf64cac6c # 2.41.0
 
 COPY ghcommit /ghcommit
 


### PR DESCRIPTION
closes #13 