### PR TITLE
GHA: only run goreleaser snapshot test on non-main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,28 @@ jobs:
 
       - run: make lint
       - run: make test
+
+  release-test:
+    runs-on: ubuntu-latest
+    # only run goreleaser snapshot on non-main branch
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52.2
+
+      # installed here to run lint on the .goreleaser.yml file:
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          install-only: true
+
       - run: make snapshot
 
   release:


### PR DESCRIPTION
main merges were running goreleaser twice which is expensive and time consuming