### PR TITLE
ci(gha): split ci and release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,11 +10,6 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  # these perms needed for goreleaser to publish releases and docker images (https://goreleaser.com/ci/actions/#token-permissions):
-  contents: write
-  packages: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -37,8 +32,6 @@ jobs:
       - run: make test
 
   release-test:
-    # only run goreleaser snapshot on non-main branch
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
@@ -55,40 +48,3 @@ jobs:
           install-only: true
 
       - run: make snapshot
-
-  release:
-    if: github.ref == 'refs/heads/main'
-    needs: [test]
-    runs-on: ubuntu-latest
-    # only create a release on main builds:
-    steps:
-      - name: checkout code with full history (unshallow)
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
-        with:
-          go-version-file: go.mod
-
-      - name: install autotag binary
-        run: |
-          curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/local/bin
-
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6
-        with:
-          install-only: true
-
-      - name: login to ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: do release
-        run: make release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,70 @@
+name: release
+
+# release process:
+#
+# on main branch merge:
+# 1. Calculate next semantic version tag (autotag)
+# 2. invoke goreleaser to build binaries, docker images, and generate GH release with new version tag
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - go.sum
+      - '**.go'
+      - .goreleaser.yml
+      - Dockerfile
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'push' && !contains(toJson(github.event.commits), '[ci skip]') && !contains(toJson(github.event.commits), '[skip ci]'))
+      || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - run: make lint
+      - run: make test
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: checkout code with full history (unshallow)
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+        with:
+          go-version-file: go.mod
+
+      - name: install autotag binary
+        run: |
+          curl -sL https://git.io/autotag-install | sh -s -- -b "${RUNNER_TEMP}/bin"
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6
+        with:
+          install-only: true
+
+      - name: login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: do release
+        run: make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2 # goreleaser config format
+
 project_name: ghcommit
 
 builds:
@@ -107,3 +109,4 @@ dockers:
       - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}-arm64"
       - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
       - "ghcr.io/planetscale/ghcommit:latest-arm64"
+# TODO: generate multi-arch docker image manifests


### PR DESCRIPTION
split ci.yaml into ci.yaml + release.yaml

release.yaml will only run when:
1. push/merge to `main` + only if specific files change, eg: dockerfile, *.go
2. or, manually invoked via github UI

The goal here is to reduce the number of automated releases that are generated. We only want to cut a new release on PRs that actually change the code (*.go) or the docker runtime image