### PR TITLE
ci: fix PATH in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,7 @@ jobs:
       - name: install autotag binary
         run: |
           curl -sL https://git.io/autotag-install | sh -s -- -b "${RUNNER_TEMP}/bin"
+          echo "${RUNNER_TEMP}/bin" >> $GITHUB_PATH
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6


### PR DESCRIPTION
A previous PR changed to installing the autotag binary into $RUNNER_TEMP/bin instead of /usr/local/bin so that sudo would not be required, but we need to add this to PATH