### PR TITLE
feat: add support for GitHub Enterprise

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const githubGraphQLURL = "https://api.github.com/graphql"
+
 var version = "development"
 
 var opts struct {
@@ -52,9 +54,17 @@ func main() {
 		log.Fatal("GITHUB_TOKEN env var must be set")
 	}
 
+	ghes := os.Getenv("GITHUB_GRAPHQL_URL")
+
 	tok := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ght})
 	httpClient := oauth2.NewClient(ctx, tok)
-	client := githubv4.NewClient(httpClient)
+
+	var client *githubv4.Client
+	if ghes == githubGraphQLURL {
+		client = githubv4.NewClient(httpClient)
+	} else {
+		client = githubv4.NewEnterpriseClient(ghes, httpClient)
+	}
 
 	// parse the commit message into headline and body
 	headline, body := parseMessage(opts.Message)


### PR DESCRIPTION
This PR adds compatibility with Github Enterprise. It will check for the value of the [`GITHUB_GRAPHQL_URL`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables:~:text=event.json.-,GITHUB_GRAPHQL_URL,-Returns%20the%20GraphQL) env variable that is automatically set in GitHub action runners. If the env var does not match the default value used by github.com, it will instead use the `githubv4.NewEnterpriseClient` function to create the client.