### PR TITLE
docker: fix arm64 image and generate multiarch manifests

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,6 +86,10 @@ release:
 dockers:
   # primary docker image for amd64 arch
   - dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
     ids:
       - ghcommit
     goos: linux
@@ -98,6 +102,10 @@ dockers:
       - "ghcr.io/planetscale/ghcommit:latest"
   # build a docker image for arm64 arch
   - dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
     ids:
       - ghcommit
     goos: linux
@@ -109,4 +117,25 @@ dockers:
       - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}-arm64"
       - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
       - "ghcr.io/planetscale/ghcommit:latest-arm64"
-# TODO: generate multi-arch docker image manifests
+
+# use `docker_manifests` section to create combined multi-arch image manifests:
+docker_manifests:
+  - name_template: "ghcr.io/planetscale/ghcommit:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/planetscale/ghcommit:{{ .Tag }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/planetscale/ghcommit:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}-arm64"
+
+  - name_template: "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}-arm64"
+
+  - name_template: "ghcr.io/planetscale/ghcommit:latest"
+    image_templates:
+      - "ghcr.io/planetscale/ghcommit:latest-amd64"
+      - "ghcr.io/planetscale/ghcommit:latest-arm64"


### PR DESCRIPTION
goreleaser was creating an arm64 image containing the correct arm64 build of `ghcommit` but the rest of the packages (eg: /usr/bin/git) were amd64 binaries. Fix this by using buildx and explicitly setting --platform to linux/arm64

also we were not yet creating multi-arch manifests so downstream consumers would need to explicitly pull the `<tag>-arm64` tag variants. this should no longer be necessary with the creation of multi-arch manifests

re:
- https://github.com/planetscale/ghcommit-action/issues/81