### PR TITLE
docker: fix multiarch build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,11 +95,11 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - "ghcr.io/planetscale/ghcommit:{{ .Tag }}"
-      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}"
-      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "ghcr.io/planetscale/ghcommit:latest"
+      - "ghcr.io/planetscale/ghcommit:{{ .Tag }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "ghcr.io/planetscale/ghcommit:latest-amd64"
   # build a docker image for arm64 arch
   - dockerfile: Dockerfile
     use: buildx


### PR DESCRIPTION
the amd64 image variants should be suffixed with -amd64 so as to not shadow our new multiarch manifests

followup fix to https://github.com/planetscale/ghcommit/pull/99