### PR TITLE
Update deprecated attributes in `.goreleaser.yml`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,8 @@ builds:
 archives:
   # binary-only releases - all platforms
   - id: binaries
-    format: binary
+    formats:
+      - binary
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
   # archive releases containing: binary, readme, and license. tarballs (macos, linux), zip (windows)
   - id: archives
@@ -43,7 +44,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
`archives.format` and `archives.format_overrides.format` have been updated to be plural (`formats`) and can now accept a list.

---

This should fix the broken build in #102 